### PR TITLE
Allow sharing the host's IPC namespace

### DIFF
--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -21,6 +21,7 @@ let
 in {
   options.bubblewrap = {
     network = mkEnableOption "network access in the sandbox" // { default = true; };
+    shareIpc = mkEnableOption "host IPC namespace in the sandbox";
 
     bind.rw = mkOption {
       description = "Read-write paths to bind-mount into the sandbox.";

--- a/modules/flatpak-shim/flatpak-info.nix
+++ b/modules/flatpak-shim/flatpak-info.nix
@@ -30,7 +30,10 @@ in
     sharedNamespaces = mkOption {
       description = "Indicate shared/unshared status of namespaces";
       type = with types; listOf (enum [ "ipc" "network" ]);
-      default = lib.optional config.bubblewrap.network "network";
+      default = (
+        (lib.optional config.bubblewrap.network "network")
+        ++ (lib.optional config.bubblewrap.shareIpc "ipc")
+      );
     };
 
     info = mkOption {

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -50,7 +50,14 @@ let
   dbusOutsidePath = concat (env "XDG_RUNTIME_DIR") (concat "/nixpak-bus-" instanceId);
   
   bwrapArgs = flatten [
-    "--unshare-all"
+    # This is the equivalent of --unshare-all, see bwrap(1) for details.
+    "--unshare-user-try"
+    (optionals (!config.bubblewrap.shareIpc) "--unshare-ipc")
+    "--unshare-pid"
+    "--unshare-net"      
+    "--unshare-uts"
+    "--unshare-cgroup-try"
+
     bindPaths
     bindRoPaths
     envVars


### PR DESCRIPTION
This PR introduces a new option `bubblewrap.shareIPC`, which is the equivalent of doing `--share=ipc` when building a Flatpak.