### PR TITLE
Add config options for typical user sockets

### DIFF
--- a/modules/lib/sloth.nix
+++ b/modules/lib/sloth.nix
@@ -85,5 +85,7 @@ in
     xdgCacheHome = sloth.envOr "XDG_CACHE_HOME" (sloth.concat' sloth.homeDir "/.cache");
 
     xdgConfigHome = sloth.envOr "XDG_CONFIG_HOME" (sloth.concat' sloth.homeDir "/.config");
+
+    runtimeDir = sloth.env "XDG_RUNTIME_DIR";
   };
 }


### PR DESCRIPTION
This allows bind-mounting the current Wayland socket, among others.