### PR TITLE
Add more XDG base directories to sloth

### DIFF
--- a/modules/lib/sloth.nix
+++ b/modules/lib/sloth.nix
@@ -86,6 +86,10 @@ in
 
     xdgConfigHome = sloth.envOr "XDG_CONFIG_HOME" (sloth.concat' sloth.homeDir "/.config");
 
+    xdgDataHome = sloth.envOr "XDG_DATA_HOME" (sloth.concat' sloth.homeDir "/.local/share");
+
+    xdgStateHome = sloth.envOr "XDG_STATE_HOME" (sloth.concat' sloth.homeDir "/.local/state");
+
     runtimeDir = sloth.env "XDG_RUNTIME_DIR";
   };
 }


### PR DESCRIPTION
This adds `xdgDataHome` and `xdgStateHome` as shortcuts to their respective environment variables to sloth.