### PR TITLE
Add option to bind only necessary store paths

### DIFF
--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -47,6 +47,14 @@ in {
       default = [];
     };
 
+    bindEntireStore = mkEnableOption "Bind entire nix store." // { default = true; };
+
+    extraStorePaths = mkOption {
+      description = "Extra nix store paths that will be recursively bound.";
+      type = types.listOf types.package;
+      default = [];
+    };
+
     sockets = {
       wayland = mkMountToggle "the active Wayland socket" // { default = false; };
       pipewire = mkMountToggle "the first PipeWire socket" // { default = false; };

--- a/modules/gui/fonts.nix
+++ b/modules/gui/fonts.nix
@@ -50,6 +50,7 @@ with lib;
       pathsToLink = "/etc/fonts";
     };
   in mkIf cfg.enable {
+    bubblewrap.extraStorePaths = [ fc ];
     bubblewrap.bind.ro = [
       [ "${fc}/etc/fonts" "/etc/fonts" ]
     ];


### PR DESCRIPTION
This adds the option to bind only the store paths that are necessary for the execution of the application. I get the store paths from the existing `info` variable and add an option for `extraStorePaths` that will be added to the `rootPaths` of the `closureinfo` call.

I made the option  (`bindEntireNixStore`) opt-out because there are some inconveniences that make it difficult to use. Here are some things I had to add to `extraStorePaths` to get Firefox working correctly:

- `homeConfig.home-files` for `home-manager`'s configuration to be accessible in the sandbox
- `systemConfig.hardware.opengl.package` for access to the GPU driver
- `systemConfig.hardware.opengl.extraPackages` for access to the VAAPI driver
- Fonts will need to be configured explicitly with the `fonts.fonts` option