### PR TITLE
Bind /etc/hosts and /etc/resolv.conf when bubblewrap.network = true

### DIFF
--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -84,7 +84,9 @@ in {
     bubblewrap.bind.ro = let
       cfg = config.bubblewrap.sockets;
     in
-      (optional cfg.wayland (sloth.concat [sloth.runtimeDir "/" (sloth.envOr "WAYLAND_DISPLAY" "wayland-0")]))
+      (optional config.bubblewrap.network "/etc/resolv.conf")
+      ++ (optional config.bubblewrap.network "/etc/hosts")
+      ++ (optional cfg.wayland (sloth.concat [sloth.runtimeDir "/" (sloth.envOr "WAYLAND_DISPLAY" "wayland-0")]))
       ++ (optional cfg.pipewire (sloth.concat' sloth.runtimeDir "/pipewire-0"))
       ++ (optionals cfg.x11 [
         (sloth.env "XAUTHORITY")


### PR DESCRIPTION
With a normal Flatpak application, `flatpak-session-helper` links a [few files](https://github.com/flatpak/flatpak/blob/f66b1ecb7420ba56bc57cada92a1ed01a5a330f9/session-helper/flatpak-session-helper.c#L859-L863), including `/etc/hosts` and `/etc/resolv.conf` into the container.

Since these files are created with the expectation that they will be readable by any application, and are often required for resolving hostnames correctly, I think it makes sense to bind them whenever `bubblewrap.network = true`.