### PR TITLE
Add module to bind Flatpak /run/host/monitor files from host

### DIFF
--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -81,12 +81,15 @@ in {
   };
 
   config = {
+    monitor = mkIf config.bubblewrap.network {
+      hostconf = true;
+      hosts = true;
+      resolvconf = true;
+    };
     bubblewrap.bind.ro = let
       cfg = config.bubblewrap.sockets;
     in
-      (optional config.bubblewrap.network "/etc/resolv.conf")
-      ++ (optional config.bubblewrap.network "/etc/hosts")
-      ++ (optional cfg.wayland (sloth.concat [sloth.runtimeDir "/" (sloth.envOr "WAYLAND_DISPLAY" "wayland-0")]))
+      (optional cfg.wayland (sloth.concat [sloth.runtimeDir "/" (sloth.envOr "WAYLAND_DISPLAY" "wayland-0")]))
       ++ (optional cfg.pipewire (sloth.concat' sloth.runtimeDir "/pipewire-0"))
       ++ (optionals cfg.x11 [
         (sloth.env "XAUTHORITY")

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -15,6 +15,7 @@ lib.evalModules {
     ./gpu.nix
     ./launch.nix
     ./locale.nix
+    ./monitor.nix
 
     ./flatpak-shim/flatpak-desktop-file.nix
     ./flatpak-shim/flatpak-info.nix

--- a/modules/monitor.nix
+++ b/modules/monitor.nix
@@ -1,0 +1,25 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  cfg = config.monitor;
+
+  mkMonitorOption = _path: default: mkEnableOption "bind mount for ${_path}" // {
+    inherit _path default;
+  };
+in
+
+rec {
+  options.monitor = {
+    hostconf = mkMonitorOption "/etc/host.conf" false;
+    hosts = mkMonitorOption "/etc/hosts" false;
+    resolvconf = mkMonitorOption "/etc/resolv.conf" false;
+    localtime = mkMonitorOption "/etc/localtime" true;
+    timezone = mkMonitorOption "/etc/timezone" true;
+  };
+
+  config.bubblewrap.bind.ro = mapAttrsToList
+    (n: v: options.monitor.${n}._path) # Get the option's bind path
+    (filterAttrs (n: v: v) cfg); # Only options that are set
+}


### PR DESCRIPTION
I noticed the time in my sandbox was incorrect because the `/etc/localtime` and `/etc/timezone` files were not present.

Flatpak provides these files along with `hosts`, `hosts.conf`, and `resolv.conf` to the sandbox using the `/run/host/monitor` links created by `flatpak-session-helper`.

I though it would make sense to consolidate these files into a new nixpak module. I called the module "monitor" like the Flatpak directory, but the name is not technically accurate since it lacks the actual file monitoring capabilities provided by the session helper, a more accurate name would probably be better. 

Another option may be to add the `flatpak-session-helper` service to nixpak since it is not strictly tied to the Flatpak runtime, or to just add simple bubblewrap options for these 2 additional files 🤷.

