### PR TITLE
launcher: rename deprecated `vendorSha256` to `vendorHash`

### DIFF
--- a/launcher/default.nix
+++ b/launcher/default.nix
@@ -8,5 +8,5 @@ buildGoModuleNoCC {
   pname = "nixpak-launcher";
   version = "2.0.0";
   src = ./.;
-  vendorSha256 = null;
+  vendorHash = null;
 }


### PR DESCRIPTION
While having nixpak as a dependency, errors are thrown because vendorSha256 is deprecated. Quick PR addressing the issue.