### PR TITLE
Respect `config.gpu.enable` flag

### DIFF
--- a/modules/gpu.nix
+++ b/modules/gpu.nix
@@ -26,7 +26,7 @@ in
       default = pkgs.mesa.drivers;
     };
   };
-  config.bubblewrap = rec {
+  config.bubblewrap = mkIf config.gpu.enable rec {
     raw = {
       bind.ro = [
         "/sys/dev/char"


### PR DESCRIPTION
Currently, `config.gpu.enable` is ignored and GPU devices are always mapped. This pull request allows disabling the mapping of GPU devices.

It also changes the default behavior, since the default value of `config.gpu.enable` was always `false`. To retain the old behavior, we could change the default value to `true`. However, this does not seem to be a safe default.