### PR TITLE
Retain meta from wrapper script during buildEnv

### DIFF
--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -186,7 +186,7 @@ in {
   };
 
   config.env = pkgs.buildEnv {
-    inherit (config.script) name;
+    inherit (config.script) name meta;
     paths = [
       (hiPrio config.script)
       (hiPrio envOverrides)


### PR DESCRIPTION
Currently, no metadata is set for the environment, which leads to the wrong assumption that the main program used when running the environment equals the package name. In our case this is the original package name prefixed with "nixpak-".
However, the wrapper script is named like the original main program, which leads to errors like the following when running the environment:

```
error: unable to execute '/nix/store/apnm35wckzlq4nqcmk3zpwys07srn9y4-nixpak-ungoogled-chromium-127.0.6533.99/bin/nixpak-ungoogled-chromium': No such file or directory
```

This commit retains the metadata from the wrapper script when building the environment, which also copies `meta.mainProgram`. Therefore, the correct main program is detected when running the environment.

This might also partly fix https://github.com/nixpak/pkgs/issues/24.