### PR TITLE
Add support for user-space networking via pasta

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > Nix? Flatpak? Why not both?
 
 NixPak is essentially a fancy declarative wrapper around
-[bwrap](https://github.com/containers/bubblewrap) and
+[bwrap](https://github.com/containers/bubblewrap),
+[pasta](https://passt.top/) and
 [xdg-dbus-proxy](https://github.com/flatpak/xdg-dbus-proxy).
 You can use it to sandbox all sorts of Nix-packaged applications,
 including graphical ones.

--- a/README.md
+++ b/README.md
@@ -182,3 +182,19 @@ sloth.concat [
 ]
 # looks something like "/run/user/1000/my-app-jim1rivq0gblz0vn6k32wgv7aq"
 ```
+
+#### `sloth.uid :: Sloth`
+
+UID of the user at runtime.
+
+```nix
+sloth.uid # results in "1000" at runtime
+```
+
+#### `sloth.gid :: Sloth`
+
+GID of the user at runtime.
+
+```nix
+sloth.gid # results in "100" at runtime
+```

--- a/examples/pasta.nix
+++ b/examples/pasta.nix
@@ -1,0 +1,20 @@
+{ mkNixPak, busybox, iproute2, curl }:
+
+mkNixPak {
+  config = { sloth, ... }: {
+    dbus.policies = { };
+    pasta.enable = true;
+    bubblewrap = {
+      bind.rw = [
+        [
+          (sloth.mkdir (sloth.concat' "/tmp/nixpak-pasta-example-" sloth.uid))
+          sloth.homeDir
+        ]
+      ];
+      env = {
+        PATH = "${curl}/bin:${iproute2}/bin:${busybox}/bin";
+      };
+    };
+    app.package = busybox;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,11 @@
           inherit mkNixPak;
           inherit (pkgs) vim;
         }).config.env;
+
+        pasta = (import ./examples/pasta.nix {
+          inherit mkNixPak;
+          inherit (pkgs) busybox iproute2 curl;
+        }).config.script;
       };
     };
   };

--- a/launcher/default.nix
+++ b/launcher/default.nix
@@ -8,5 +8,5 @@ buildGoModuleNoCC {
   pname = "nixpak-launcher";
   version = "2.0.0";
   src = ./.;
-  vendorHash = null;
+  vendorHash = "sha256-b+OnCivNo2RpfPupdAdfqR2ywDWKcDDru5yDfxw1Tvs=";
 }

--- a/launcher/default.nix
+++ b/launcher/default.nix
@@ -6,7 +6,7 @@ in
 
 buildGoModuleNoCC {
   pname = "nixpak-launcher";
-  version = "2.0.0";
+  version = "3.0.0";
   src = ./.;
   vendorHash = "sha256-b+OnCivNo2RpfPupdAdfqR2ywDWKcDDru5yDfxw1Tvs=";
 }

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -1,3 +1,5 @@
 module github.com/nixpak/nixpak/launcher
 
 go 1.18
+
+require golang.org/x/sys v0.29.0 // indirect

--- a/launcher/go.sum
+++ b/launcher/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -295,6 +295,7 @@ func StartBwrap(conf Config) (bwrap Bwrap) {
 
 	cmd := exec.Command(conf.BwrapExe, bwrapArgs...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -383,7 +383,10 @@ func (bwrap *Bwrap) WaitUntilChildExit() {
 		panic(err)
 	}
 	if _, err := bwrapChild.Wait(); err != nil {
-		panic(err)
+		syscallErr, ok := err.(*os.SyscallError)
+		if !ok || syscallErr.Unwrap() != unix.ECHILD {
+			panic(err)
+		}
 	}
 }
 

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -77,6 +77,32 @@ func (i InstanceId) String() string {
 	return i.Id
 }
 
+type Uid struct {
+	Type string
+}
+
+func NewUid(raw JsonRaw) (u Uid) {
+	u.Type = "uid"
+	return
+}
+
+func (u Uid) String() string {
+	return strconv.Itoa(os.Getuid())
+}
+
+type Gid struct {
+	Type string
+}
+
+func NewGid(raw JsonRaw) (u Gid) {
+	u.Type = "gid"
+	return
+}
+
+func (u Gid) String() string {
+	return strconv.Itoa(os.Getgid())
+}
+
 type Mkdir struct {
 	Type string
 	Dir  string
@@ -118,6 +144,10 @@ func valToString(item interface{}) (ret string) {
 			ret = NewConcat(raw).String()
 		case "instanceId":
 			ret = NewInstanceId(raw).String()
+		case "uid":
+			ret = NewUid(raw).String()
+		case "gid":
+			ret = NewGid(raw).String()
 		case "mkdir":
 			ret = NewMkdir(raw).String()
 		default:

--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -82,10 +82,11 @@ in {
 
   config = {
     bubblewrap.bind.ro = let
+      mapNetFiles = config.bubblewrap.network && !config.pasta.enable;
       cfg = config.bubblewrap.sockets;
     in
-      (optional config.bubblewrap.network "/etc/resolv.conf")
-      ++ (optional config.bubblewrap.network "/etc/hosts")
+      (optional mapNetFiles "/etc/resolv.conf")
+      ++ (optional mapNetFiles "/etc/hosts")
       ++ (optional cfg.wayland (sloth.concat [sloth.runtimeDir "/" (sloth.envOr "WAYLAND_DISPLAY" "wayland-0")]))
       ++ (optional cfg.pipewire (sloth.concat' sloth.runtimeDir "/pipewire-0"))
       ++ (optionals cfg.x11 [

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -10,6 +10,7 @@ lib.evalModules {
     
     ./app.nix
     ./bubblewrap.nix
+    ./pasta.nix
     ./dbus.nix
     ./etc.nix
     ./gpu.nix

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, pkgs, sloth, ... }:
 with lib;
 let
   # most of the things here should probably be incorporated into a module
@@ -50,7 +50,18 @@ let
   launcher = pkgs.callPackage ../launcher {};
   dbusOutsidePath = concat (env "XDG_RUNTIME_DIR") (concat "/nixpak-bus-" instanceId);
   
+  pastaEnable = config.bubblewrap.network && config.pasta.enable;
+  originalBwrapExe = "${config.bubblewrap.package}/bin/bwrap";
+  bwrapExe = if pastaEnable then "${config.pasta.package}/bin/pasta" else originalBwrapExe;
   bwrapArgs = flatten [
+    (optionals pastaEnable [
+      config.pasta.args
+      "--"
+      originalBwrapExe
+      "--uid" sloth.uid
+      "--gid" sloth.gid
+    ])
+
     # This is the equivalent of --unshare-all, see bwrap(1) for details.
     "--unshare-user-try"
     (optionals (!config.bubblewrap.shareIpc) "--unshare-ipc")
@@ -106,7 +117,7 @@ let
   } (''
     makeWrapper ${launcher}/bin/launcher $out${executablePath} \
       ${concatStringsSep " " (flatten [
-        "--set BWRAP_EXE ${config.bubblewrap.package}/bin/bwrap"
+        "--set BWRAP_EXE ${bwrapExe}"
         "--set NIXPAK_APP_EXE ${app}${executablePath}"
         "--set BUBBLEWRAP_ARGS ${bwrapArgsJson}"
         (optionals config.dbus.enable "--set XDG_DBUS_PROXY_EXE ${dbusProxyWrapper}")

--- a/modules/lib/sloth.nix
+++ b/modules/lib/sloth.nix
@@ -24,6 +24,13 @@ in
       type = "instanceId";
     };
 
+    uid = {
+      type = "uid";
+    };
+    gid = {
+      type = "gid";
+    };
+
     env = key: {
       inherit key;
       type = "env";

--- a/modules/pasta.nix
+++ b/modules/pasta.nix
@@ -1,0 +1,75 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.pasta = {
+    enable = mkEnableOption "Pasta networking";
+    package = mkOption {
+      description = "Pasta package to use.";
+      type = types.package;
+      default = pkgs.passt;
+    };
+    mode = mkOption {
+      type = types.enum [ "transparent" "isolate" ];
+      description = "Operation mode of pasta.";
+      default = "isolate";
+    };
+    args = mkOption {
+      type = types.listOf types.str;
+      description = "Arguments (networking options) to pasta.";
+      default = [];
+    };
+  };
+  config.pasta.args = flatten [
+    "--config-net"
+    # Disable services not needed due to --config-net
+    "--no-dhcp"
+    "--no-dhcpv6"
+    "--no-ndp"
+    "--no-ra"
+    # Mapping the gateway address to host also does not make sense in transparent mode, because this would prevent connections to the original gateway copied from host
+    "--no-map-gw"
+    (optionals (config.pasta.mode == "isolate") [
+      # Disable port forwarding to host
+      "--tcp-ns" "none"
+      "--udp-ns" "none"
+      # Disable port forwarding to sandbox
+      "--tcp-ports" "none"
+      "--udp-ports" "none"
+      # Use common generic addresses to avoid fingerprinting
+      "--ns-ifname" "eth0"
+      "--address" "192.168.1.100"
+      "--netmask" "255.255.255.0"
+      "--gateway" "192.168.1.1"
+      "--mac-addr" "52:54:00:12:34:56"
+      "--dns-forward" "192.168.1.1"
+      "--search" "none"
+    ])
+  ];
+  config.bubblewrap = let
+    pastaEnable = config.bubblewrap.network && config.pasta.enable;
+    resolvConfFile = pkgs.writeTextDir "etc/resolv.conf" ''
+      nameserver 192.168.1.1
+    '';
+    hostsFile = pkgs.writeTextDir "etc/hosts" ''
+      127.0.0.1 localhost
+      ::1 localhost
+      192.168.1.100 localhost
+    '';
+  in mkMerge [
+    (mkIf (pastaEnable && config.pasta.mode == "transparent") {
+      bind.ro = [
+        "/etc/resolv.conf"
+        "/etc/hosts"
+      ];
+    })
+    (mkIf (pastaEnable && config.pasta.mode == "isolate") {
+      extraStorePaths = [ resolvConfFile hostsFile ];
+      bind.ro = [
+        [ "${resolvConfFile}/etc/resolv.conf" "/etc/resolv.conf" ]
+        [ "${hostsFile}/etc/hosts" "/etc/hosts" ]
+      ];
+    })
+  ];
+}

--- a/modules/pasta.nix
+++ b/modules/pasta.nix
@@ -8,7 +8,17 @@ with lib;
     package = mkOption {
       description = "Pasta package to use.";
       type = types.package;
-      default = pkgs.passt;
+      default = pkgs.passt.overrideAttrs (old: {
+        patches = (old.patches or []) ++ [
+          # This patch let's pasta get the user namespace from the mount namespace.
+          # This is necessary, since bubblewrap sometimes (e.g. when the --dev option
+          # is used) uses two layers of user namespaces and pasta sometimes (since
+          # also a race-condition is involved; see
+          # https://github.com/containers/bubblewrap/issues/634) fails to detect the
+          # correct user namespace.
+          ./patches/passt-fix-user-namespace-detection.patch
+        ];
+      });
     };
     mode = mkOption {
       type = types.enum [ "transparent" "isolate" ];

--- a/modules/patches/passt-fix-user-namespace-detection.patch
+++ b/modules/patches/passt-fix-user-namespace-detection.patch
@@ -1,0 +1,40 @@
+diff --git a/conf.c b/conf.c
+index 36845e2..cd67e7a 100644
+--- a/conf.c
++++ b/conf.c
+@@ -642,7 +642,7 @@ static void conf_pasta_ns(int *netns_only, char *userns, char *netns,
+ 
+ 			if (!*userns) {
+ 				if (snprintf_check(userns, PATH_MAX,
+-						   "/proc/%ld/ns/user", pidval))
++						   "/proc/%ld/ns/net", pidval))
+ 					die_perror("Can't build userns path");
+ 			}
+ 		}
+diff --git a/isolation.c b/isolation.c
+index bbcd23b..cbfe0f0 100644
+--- a/isolation.c
++++ b/isolation.c
+@@ -81,6 +81,7 @@
+ #include <linux/audit.h>
+ #include <linux/capability.h>
+ #include <linux/filter.h>
++#include <linux/nsfs.h>
+ #include <linux/seccomp.h>
+ 
+ #include "util.h"
+@@ -254,6 +255,14 @@ void isolate_user(uid_t uid, gid_t gid, bool use_userns, const char *userns,
+ 		if (ufd < 0)
+ 			die_perror("Couldn't open user namespace %s", userns);
+ 
++		int real_ufd;
++		real_ufd = ioctl(ufd, NS_GET_USERNS);
++		if (real_ufd < 0)
++			die_perror("Couldn't get user namespace from network namespace %s", userns);
++
++		close(ufd);
++		ufd = real_ufd;
++
+ 		if (setns(ufd, CLONE_NEWUSER) != 0)
+ 			die_perror("Couldn't enter user namespace %s", userns);
+ 


### PR DESCRIPTION
This pull request adds support for user-space networking via pasta ~~and enables it by default~~.

### Rational

Flatpak only supports sharing the network namespace with the host. This is especially problematic with abstract UNIX sockets (like the X11 abstract UNIX socket), since they can be accessed just by knowing the name.

For protecting against these attacks, we either need to fully block abstract UNIX sockets via seccomp or use a separate network namespace. We are going the route via a separate network namespace, since it is the better sandboxing approach. Futhermore, it provides more flexibility.

There are essentially two options to provide external network access in a separate namespace. Either use the kernel, which requires root access, since devices are added in the host network namespace. Or use user-space networking, which maps Layer-2 traffic from the sandbox to unprivileged Layer-4 (TCP, UDP, ...) sockets on the host.

One popular implementation of user-space networking is slirp4netns, which was initially used by Podman to provide rootless networking. However, it implements a full TCP/IP stack in user-space. Pasta is another user-space networking implementation, which tries to be more clever and avoids having to implement a full TCP/IP stack in user-space. Nowadays, Podman also uses pasta by default to provide rootless networking.