### PR TITLE
Expose extendModules on sandbox packages to make them extensible

### DIFF
--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -168,7 +168,7 @@ let
   '';
 
   passthru = {
-    nixpakExtendModules = config._module.args.extendModules;
+    extendModules = config._module.args.extendModules;
   };
 in {
   options = {


### PR DESCRIPTION
This change allows users to update sandboxes, even if they only have access to the final package(eg. when using flake outputs)

An example use case is switching the chrome package from nixpak/pkgs  to using the nixos gpu provider.

```
chromium.nixpakExtendModules { 
  modules = [
    ({lib, ...}: {
      gpu.provider = lib.mkForce "nixos";
    })
  ]; 
}
```