### PR TITLE
Allow sloth values to be any string, not just paths

### DIFF
--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -75,7 +75,7 @@ in {
 
     env = mkOption {
       description = "Environment variables to set.";
-      type = with types; attrsOf (oneOf [ null str sloth.type ] );
+      type = with types; attrsOf (nullOr sloth.type);
       default = {};
     };
   };

--- a/modules/lib/sloth.nix
+++ b/modules/lib/sloth.nix
@@ -14,8 +14,8 @@ in
     type = with lib; mkOptionType {
       name = "sloth value";
       check = x:
-        # path style
-        (types.path.check x)
+        # string style
+        (types.str.check x)
         # sloth style
         || (isAttrs x && x ? type && any (t: x.type == t) knownTypes);
     };


### PR DESCRIPTION
Even though sloth values are mostly used for paths, they're probably useful for strings in general. This PR loosens the type check to enable that. Also fixes a problem introduced by https://github.com/nixpak/nixpak/pull/103 (https://hercules-ci.com/github/nixpak/nixpak/jobs/433).