### PR TITLE
Feature: flatpak instance shim

### DIFF
--- a/modules/flatpak-shim/flatpak-info.nix
+++ b/modules/flatpak-shim/flatpak-info.nix
@@ -54,6 +54,7 @@ in
         name = config.flatpak.appId;
         runtime = config.flatpak.runtimeId;
       };
+      Instance.instance-id = "MY_INSTANCE_ID";
       Context.shared = "${concatStringsSep ";" config.flatpak.sharedNamespaces};";
       "Session Bus Policy" = config.dbus.policies;
     };

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -76,8 +76,6 @@ let
       (concat "unix:path=" (coerceToEnv "$XDG_RUNTIME_DIR/nixpak-bus"))
     ])
 
-    [ "--ro-bind" config.flatpak.infoFile "/.flatpak-info" ]
-
     (optionals config.bubblewrap.bindEntireStore (bindRo "/nix/store"))
   ];
   dbusProxyArgs = [ (env "DBUS_SESSION_BUS_ADDRESS") dbusOutsidePath ] ++ config.dbus.args ++ [ "--filter" ];
@@ -107,8 +105,10 @@ let
     makeWrapper ${launcher}/bin/launcher $out${executablePath} \
       ${concatStringsSep " " (flatten [
         "--set BWRAP_EXE ${config.bubblewrap.package}/bin/bwrap"
-        "--set NIXPAK_APP_EXE ${app}${executablePath}"
         "--set BUBBLEWRAP_ARGS ${bwrapArgsJson}"
+        "--set NIXPAK_APP_NAME ${name}"
+        "--set NIXPAK_APP_EXE ${app}${executablePath}"
+        "--set NIXPAK_APP_INFO ${config.flatpak.infoFile}"
         (optionals config.dbus.enable "--set XDG_DBUS_PROXY_EXE ${dbusProxyWrapper}")
         (optionals config.dbus.enable "--set XDG_DBUS_PROXY_ARGS ${dbusProxyArgsJson}")
       ])}
@@ -163,7 +163,7 @@ let
       (bind "/var")
       (bind "/tmp")
       (bind "/run")
-      "--ro-bind-try ${config.flatpak.infoFile or "/.flatpak-info-not-found"} /.flatpak-info"
+      "--ro-bind-try \${NIXPAK_INSTANCE_PATH}/info /.flatpak-info"
     ])} ${pkgs.xdg-dbus-proxy}/bin/xdg-dbus-proxy "$@"
   '';
 


### PR DESCRIPTION
This should implement the feature requested in #7 

Instead of using a static `/.flatpak-info` file from `/nix/store` it copies the file and sets a random instance-id. The GoLang based wrapper now also creates `$XDG_RUNTIME_DIR/.flatpak/<instance-id>` and opens a file descriptor for bubblewrap to write his status info into (`--info-fd`).

It is currently not the nicest way to implement this, but my host dbus service began denying requests from nixpak sandboxed application after a recent nixpkgs update a few days ago and this solves it for now.