### PR TITLE
Add Wayland proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 > Nix? Flatpak? Why not both?
 
 NixPak is essentially a fancy declarative wrapper around
-[bwrap](https://github.com/containers/bubblewrap),
-[pasta](https://passt.top/),
-[xdg-dbus-proxy](https://github.com/flatpak/xdg-dbus-proxy) and
-[wayland-proxy-virtwl](https://github.com/talex5/wayland-proxy-virtwl).
+[bwrap](https://github.com/containers/bubblewrap).
 You can use it to sandbox all sorts of Nix-packaged applications,
 including graphical ones.
+
+It also optionally integrates with the following tools:
+- [pasta](https://passt.top/) for highly customizable network isolation
+- [xdg-dbus-proxy](https://github.com/flatpak/xdg-dbus-proxy) for D-Bus service access control
+- [wayland-proxy-virtwl](https://github.com/talex5/wayland-proxy-virtwl) for Wayland protocol access control
 
 ## Features
 
@@ -34,7 +36,7 @@ Also see the [examples directory](./examples)
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
-    
+
   outputs = { self, nixpkgs, nixpak }: {
     packages.x86_64-linux = let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 NixPak is essentially a fancy declarative wrapper around
 [bwrap](https://github.com/containers/bubblewrap),
-[pasta](https://passt.top/) and
-[xdg-dbus-proxy](https://github.com/flatpak/xdg-dbus-proxy).
+[pasta](https://passt.top/),
+[xdg-dbus-proxy](https://github.com/flatpak/xdg-dbus-proxy) and
+[wayland-proxy-virtwl](https://github.com/talex5/wayland-proxy-virtwl).
 You can use it to sandbox all sorts of Nix-packaged applications,
 including graphical ones.
 

--- a/launcher/default.nix
+++ b/launcher/default.nix
@@ -8,5 +8,5 @@ buildGoModuleNoCC {
   pname = "nixpak-launcher";
   version = "3.1.0";
   src = ./.;
-  vendorHash = "sha256-b+OnCivNo2RpfPupdAdfqR2ywDWKcDDru5yDfxw1Tvs=";
+  vendorHash = "sha256-eKvO0w/7rIY4pURRka6pzZ3kx1VBTxUZxIyT7Fb9WQ8=";
 }

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -3,3 +3,5 @@ module github.com/nixpak/nixpak/launcher
 go 1.18
 
 require golang.org/x/sys v0.29.0
+
+require github.com/fsnotify/fsnotify v1.9.0

--- a/launcher/go.sum
+++ b/launcher/go.sum
@@ -1,2 +1,4 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -272,7 +272,7 @@ func readConfig() (conf Config) {
 	if useWaylandProxy {
 		conf.WaylandProxyArgs = readJsonArgs(waylandProxyArgsJson)
 		conf.WaylandProxyExe = envOr("WAYLAND_PROXY_EXE", "wayland-proxy-virtwl")
-		conf.WaylandProxySocketPath = requiredEnv("XDG_RUNTIME_DIR") + "/nixpak-wayland-" + instanceId()
+		conf.WaylandProxySocketPath = filepath.Join(requiredEnv("XDG_RUNTIME_DIR"), "nixpak-wayland-"+instanceId())
 
 		if _, err := os.Stat(conf.WaylandProxySocketPath); err == nil {
 			panic("Wayland proxy socket already exists")
@@ -401,7 +401,7 @@ func StartBwrap(conf Config, flatpakMetadata FlatpakMetadata) (bwrap Bwrap) {
 		bwrapArgs = append(bwrapArgs, []string{"--ro-bind", flatpakMetadata.MetadataDirectory + "/info", "/.flatpak-info"}...)
 	}
 	if conf.UseWaylandProxy {
-		waylandProxySocketPathInner := requiredEnv("XDG_RUNTIME_DIR") + "/nixpak-wayland"
+		waylandProxySocketPathInner := filepath.Join(requiredEnv("XDG_RUNTIME_DIR"), "nixpak-wayland")
 		bwrapArgs = append(bwrapArgs, "--bind", conf.WaylandProxySocketPath, waylandProxySocketPathInner)
 		bwrapArgs = append(bwrapArgs, "--setenv", "WAYLAND_DISPLAY", "nixpak-wayland")
 	}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -12,6 +12,7 @@ lib.evalModules {
     ./bubblewrap.nix
     ./pasta.nix
     ./dbus.nix
+    ./wayland-proxy.nix
     ./etc.nix
     ./gpu.nix
     ./launch.nix

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -49,7 +49,6 @@ let
   info = pkgs.closureInfo { inherit rootPaths; };
   launcher = pkgs.callPackage ../launcher {};
   dbusOutsidePath = concat (env "XDG_RUNTIME_DIR") (concat "/nixpak-bus-" instanceId);
-  waylandOutsidePath = concat (env "XDG_RUNTIME_DIR") (concat "/nixpak-wayland-" instanceId);
   
   pastaEnable = config.bubblewrap.network && config.pasta.enable;
 
@@ -80,11 +79,6 @@ let
       (concat "unix:path=" (coerceToEnv "$XDG_RUNTIME_DIR/nixpak-bus"))
     ])
 
-    (optionals config.waylandProxy.enable [
-      (bind [ waylandOutsidePath "$XDG_RUNTIME_DIR/nixpak-wayland" ])
-      "--setenv" "WAYLAND_DISPLAY" "nixpak-wayland"
-    ])
-
     (optionals config.bubblewrap.bindEntireStore (bindRo "/nix/store"))
   ];
   dbusProxyArgs = [ (env "DBUS_SESSION_BUS_ADDRESS") dbusOutsidePath ] ++ config.dbus.args ++ [ "--filter" ];
@@ -101,8 +95,7 @@ let
 
   pastaArgsJson = pkgs.writeText "pasta-args.json" (builtins.toJSON config.pasta.args);
 
-  waylandProxyArgs = [ (concat "--wayland-display=" waylandOutsidePath) ] ++ config.waylandProxy.args;
-  waylandProxyArgsJson = pkgs.writeText "wayland-proxy-args.json" (builtins.toJSON waylandProxyArgs);
+  waylandProxyArgsJson = pkgs.writeText "wayland-proxy-args.json" (builtins.toJSON config.waylandProxy.args);
 
   mainProgram = builtins.baseNameOf config.app.binPath;
 

--- a/modules/wayland-proxy.nix
+++ b/modules/wayland-proxy.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.waylandProxy = {
+    enable = mkEnableOption "Proxied Wayland access" // { default = false; };
+    package = mkOption {
+      description = "Wayland-proxy-virtwl package to use.";
+      type = types.package;
+      default = pkgs.wayland-proxy-virtwl;
+    };
+    tag = mkOption {
+      type = types.str;
+      description = "Tag to prefix to window titles.";
+      default = "[${config.app.package.pname or (builtins.parseDrvName config.app.package.name).name}] ";
+    };
+    args = mkOption {
+      type = with types; listOf str;
+      description = "Arguments (proxy options) to wayland-proxy-virtwl.";
+      default = [];
+    };
+  };
+  config.waylandProxy.args = [
+    "--tag=${config.waylandProxy.tag}"
+  ];
+}

--- a/modules/wayland-proxy.nix
+++ b/modules/wayland-proxy.nix
@@ -4,7 +4,7 @@ with lib;
 
 {
   options.waylandProxy = {
-    enable = mkEnableOption "Proxied Wayland access" // { default = false; };
+    enable = mkEnableOption "Proxied Wayland access";
     package = mkOption {
       description = "Wayland-proxy-virtwl package to use.";
       type = types.package;


### PR DESCRIPTION
This adds support for proxing the Wayland socket via wayland-proxy-virtwl. It limits the supported Wayland protocols to a sane set and allows prefixing window titles.
Although wayland-proxy-virtwl currently does not fully validate the requests relayed to the Wayland compositor, it is already useful. Furthermore, it looks like it might get used in future Qubes OS releases for safeguarding the compositor. See:
* https://github.com/talex5/wayland-proxy-virtwl/issues/90
* https://github.com/talex5/ocaml-wayland/pull/49