### PR TITLE
NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       ./jobs/update-flake-lock
       ./dev
       ./contrib
+      ./nixos
     ];
 
     systems = [

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,0 +1,24 @@
+{ self, ... }:
+
+{
+  flake.nixosModules.default = ({ config, lib, pkgs, ... }@nixos: let
+    mkNixPak = self.lib.nixpak {
+      inherit lib pkgs;
+    };
+  in {
+    imports = [
+      ./nixpak-nixos-module.nix
+    ];
+    options.security.nixpak.apps = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule ({ config, name, ... }: {
+        output = mkNixPak {
+          config.imports = [
+            config.configuration
+            nixos.config.security.nixpak.defaults
+          ];
+          specialArgs = { inherit name; };
+        };
+      }));
+    };
+  });
+}

--- a/nixos/nixpak-nixos-module.nix
+++ b/nixos/nixpak-nixos-module.nix
@@ -1,0 +1,51 @@
+{ config, lib, ... }:
+let
+  inherit (lib) filterAttrs mapAttrsToList mkEnableOption mkIf mkOption pipe types;
+  cfg = config.security.nixpak;
+in
+
+{
+  options.security.nixpak = {
+    enable = mkEnableOption "NixPak application sandboxing";
+
+    defaults = mkOption {
+      description = "Configuration module to include in all applications.";
+      type = types.deferredModule;
+      default = {};
+    };
+
+    apps = mkOption {
+      description = "NixPak apps.";
+      type = types.attrsOf (types.submodule {
+        options = {
+          configuration = mkOption {
+            description = "Configuration module for this application.";
+            type = types.deferredModule;
+            default = {};
+          };
+
+          expose = mkEnableOption null // {
+            description = "Whether to expose this app via `environment.systemPackages`.";
+            default = true;
+            example = false;
+          };
+
+          output = mkOption {
+            description = "The output of mkNixPak.";
+            type = types.raw;
+            internal = true;
+            readOnly = true;
+          };
+        };
+      });
+      default = {};
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = pipe cfg.apps [
+      (filterAttrs (_: app: app.expose))
+      (mapAttrsToList (_: app: app.output.config.env))
+    ];
+  };
+}


### PR DESCRIPTION
Fixes #87 

Each NixPak module system invocation has access to the special module argument `name`, which represents the name of the attribute. `security.nixpak.defaults` is a module that will be included in every invocation.

Example usage:

```nix
{ inputs, pkgs, ... }:

{
  security.nixpak = {
    enable = true;
    defaults = { name, ... }: {
      imports = [ inputs.nixpak.nixpakModules."preset-${name}" ];
    };
    apps.hello.configuration = { sloth, ... }: {
      app.package = pkgs.hello;
      bubblewrap.network = false;
      dbus.enable = false;
      bubblewrap.bind.ro = [ sloth.homeDir ];
    };
  };
}
```