### PR TITLE
Add PipeWire support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It also optionally integrates with the following tools:
 - [pasta](https://passt.top/) for highly customizable network isolation
 - [xdg-dbus-proxy](https://github.com/flatpak/xdg-dbus-proxy) for D-Bus service access control
 - [wayland-proxy-virtwl](https://github.com/talex5/wayland-proxy-virtwl) for Wayland protocol access control
+- [pw-container](https://docs.pipewire.org/page_man_pw-container_1.html) for PipeWire access control
 
 ## Features
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -13,6 +13,7 @@ lib.evalModules {
     ./pasta.nix
     ./dbus.nix
     ./wayland-proxy.nix
+    ./pipewire.nix
     ./etc.nix
     ./gpu.nix
     ./launch.nix

--- a/modules/pipewire.nix
+++ b/modules/pipewire.nix
@@ -1,0 +1,50 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+{
+  options.pipewire = {
+    enable = mkEnableOption "PipeWire access";
+    package = mkOption {
+      description = "PipeWire package to use for PulseAudio emulation in sandbox.";
+      type = types.package;
+      default = pkgs.pipewire;
+    };
+    snapId = mkOption {
+      description = "Snap ID";
+      type = types.str;
+      default = config.flatpak.appId;
+    };
+    pulseaudio = mkEnableOption "PipeWire PulseAudio emulation in sandbox";
+    playback = mkEnableOption "PipeWire playback access";
+    capture = mkEnableOption "PipeWire capture access";
+    properties = mkOption {
+      type = with types; attrsOf str;
+      description = "Extra context properties";
+      default = {};
+    };
+    args = mkOption {
+      type = with types; listOf str;
+      description = "Arguments to pw-container";
+      default = [];
+    };
+  };
+  config.pipewire.properties = {
+    # Use Snap's PipeWire access control
+    "pipewire.snap.id" = config.pipewire.snapId;
+    "pipewire.snap.audio.playback" = if config.pipewire.playback then "true" else "false";
+    "pipewire.snap.audio.record" = if config.pipewire.capture then "true" else "false";
+    # Use Flatpak's PipeWire access control
+    #  This is only for reference, if someone wants to experiment with it and
+    #  is currently not fully supported by NixPak. We did not follow this path,
+    #  since Flatpak's access control is less flexible and directly built into
+    #  PipeWire's C code, while Snap's access control supports separated access
+    #  control for playback/record and is easier adjustable, since it is
+    #  written in Lua.
+    #"pipewire.sec.engine" = "org.flatpak";
+    #"pipewire.access" = "restricted";
+  };
+  config.pipewire.args = [
+    "--properties=${(builtins.toJSON config.pipewire.properties)}"
+  ];
+}


### PR DESCRIPTION
This is the last big change, I currently have in the pipeline ;)

This adds PipeWire support by using pw-container to create a separate security context and supplying the properties used by Snap's PipeWire access control to limit playback and recording.

This is not a proxy solution like DBus or Wayland, but only uses the security context feature integrated into PipeWire. Security-wise this is not optimal, since the sandboxed applications still directly talk to the PipeWire server. Furthermore, according to Qubes OS developers PipeWire is currently not safe for untrusted clients.
However, it is not worse than directly passing the default PipeWire socket to applications and at least some work on securing PipeWire is ongoing:

* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1384
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1385
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/1820
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2423
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2442
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2443
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2446
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2447
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2449
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2450
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2453
* https://gitlab.freedesktop.org/pipewire/pipewire/-/merge_requests/2455