### PR TITLE
Sort mount paths to allow nested paths with different permissions

### DIFF
--- a/launcher/main.go
+++ b/launcher/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/base32"
 	"encoding/json"
@@ -213,6 +214,43 @@ func waitUntilFileAppears(filename string) {
 	}
 }
 
+type ExtraBinCfg struct {
+	Enable bool
+	Exe    string
+	Args   string
+}
+
+type LauncherCfg struct {
+	App struct {
+		Exe string
+	}
+	Bwrap struct {
+		Exe  string
+		Args string
+	}
+	Flatpak struct {
+		Metadata string
+	}
+	Dbus    ExtraBinCfg
+	Pasta   ExtraBinCfg
+	Wayland ExtraBinCfg
+}
+
+func initLauncherCfg() (cfg LauncherCfg) {
+	file, _ := os.Open(os.Args[1])
+	data, _ := io.ReadAll(file)
+
+	// skip shebang for launcher
+	idx := bytes.IndexByte(data, '\n')
+	data = data[idx+1:]
+
+	err := json.Unmarshal(data, &cfg)
+	if err != nil {
+		panic("Parsing launcher config")
+	}
+	return
+}
+
 type Config struct {
 	AppExe                  string
 	AppArgs                 []string
@@ -233,47 +271,34 @@ type Config struct {
 }
 
 func readConfig() (conf Config) {
-	appExe, foundAppExe := os.LookupEnv("NIXPAK_APP_EXE")
-	if !foundAppExe {
-		panic("No executable given")
-	}
-	conf.AppExe = appExe
-	conf.AppArgs = os.Args[1:]
+	launchCfg := initLauncherCfg()
 
-	bwrapArgsJson, foundBwrapArgs := os.LookupEnv("BUBBLEWRAP_ARGS")
-	if !foundBwrapArgs {
-		panic("No bubblewrap args given")
-	}
-	conf.BwrapArgs = readJsonArgs(bwrapArgsJson)
-	conf.BwrapExe = envOr("BWRAP_EXE", "bwrap")
+	conf.AppExe = launchCfg.App.Exe
+	conf.AppArgs = os.Args[2:]
 
-	dbusproxyArgsJson, useDbusProxy := os.LookupEnv("XDG_DBUS_PROXY_ARGS")
-	conf.UseDbusProxy = useDbusProxy
-	if useDbusProxy {
-		conf.DbusproxyArgs = readJsonArgs(dbusproxyArgsJson)
-		conf.DbusproxyExe = envOr("XDG_DBUS_PROXY_EXE", "xdg-dbus-proxy")
+	conf.BwrapExe = launchCfg.Bwrap.Exe
+	conf.BwrapArgs = readJsonArgs(launchCfg.Bwrap.Args)
+
+	conf.UseDbusProxy = launchCfg.Dbus.Enable
+	if conf.UseDbusProxy {
+		conf.DbusproxyExe = launchCfg.Dbus.Exe
+		conf.DbusproxyArgs = readJsonArgs(launchCfg.Dbus.Args)
 	}
 
-	pastaArgsJson, usePasta := os.LookupEnv("PASTA_ARGS")
-	conf.UsePasta = usePasta
-	if usePasta {
-		conf.PastaArgs = readJsonArgs(pastaArgsJson)
-		conf.PastaExe = envOr("PASTA_EXE", "pasta")
+	conf.UsePasta = launchCfg.Pasta.Enable
+	if conf.UsePasta {
+		conf.PastaExe = launchCfg.Pasta.Exe
+		conf.PastaArgs = readJsonArgs(launchCfg.Pasta.Args)
 	}
 
-	flatpakMetadataTemplate, useFlatpakMetadata := os.LookupEnv("FLATPAK_METADATA_TEMPLATE")
-	conf.UseFlatpakMetadata = useFlatpakMetadata
-	if useFlatpakMetadata {
-		conf.FlatpakMetadataTemplate = flatpakMetadataTemplate
-	}
+	conf.UseFlatpakMetadata = true
+	conf.FlatpakMetadataTemplate = launchCfg.Flatpak.Metadata
 
-	waylandProxyArgsJson, useWaylandProxy := os.LookupEnv("WAYLAND_PROXY_ARGS")
-	conf.UseWaylandProxy = useWaylandProxy
-	if useWaylandProxy {
-		conf.WaylandProxyArgs = readJsonArgs(waylandProxyArgsJson)
-		conf.WaylandProxyExe = envOr("WAYLAND_PROXY_EXE", "wayland-proxy-virtwl")
+	conf.UseWaylandProxy = launchCfg.Wayland.Enable
+	if conf.UseWaylandProxy {
+		conf.WaylandProxyExe = launchCfg.Wayland.Exe
+		conf.WaylandProxyArgs = readJsonArgs(launchCfg.Wayland.Args)
 		conf.WaylandProxySocketPath = filepath.Join(requiredEnv("XDG_RUNTIME_DIR"), "nixpak-wayland-"+instanceId())
-
 		if _, err := os.Stat(conf.WaylandProxySocketPath); err == nil {
 			panic("Wayland proxy socket already exists")
 		}

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"syscall"
 
@@ -225,8 +226,9 @@ type LauncherCfg struct {
 		Exe string
 	}
 	Bwrap struct {
-		Exe  string
-		Args string
+		Exe    string
+		Args   string
+		Mounts string
 	}
 	Flatpak struct {
 		Metadata string
@@ -256,6 +258,7 @@ type Config struct {
 	AppArgs                 []string
 	BwrapExe                string
 	BwrapArgs               []string
+	BwrapMounts             []string
 	UseDbusProxy            bool
 	DbusproxyExe            string
 	DbusproxyArgs           []string
@@ -278,6 +281,7 @@ func readConfig() (conf Config) {
 
 	conf.BwrapExe = launchCfg.Bwrap.Exe
 	conf.BwrapArgs = readJsonArgs(launchCfg.Bwrap.Args)
+	conf.BwrapMounts = readJsonArgs(launchCfg.Bwrap.Mounts)
 
 	conf.UseDbusProxy = launchCfg.Dbus.Enable
 	if conf.UseDbusProxy {
@@ -406,6 +410,24 @@ func (waylandProxy *WaylandProxy) Close() {
 	os.Remove(waylandProxy.SocketPath)
 }
 
+func SortBindPaths(args []string) (newArgs []string) {
+	var bindPathPairs [][3]string
+	for i := 0; i < len(args); i++ {
+		bindPathPairs = append(bindPathPairs, [3]string{args[i], args[i+1], args[i+2]})
+		i += 2
+	}
+	sort.Slice(bindPathPairs, func(i, j int) bool {
+		a, b := bindPathPairs[i][2], bindPathPairs[j][2]
+		return a < b
+	})
+	for i := 0; i < len(bindPathPairs); i++ {
+		newArgs = append(newArgs, bindPathPairs[i][0])
+		newArgs = append(newArgs, bindPathPairs[i][1])
+		newArgs = append(newArgs, bindPathPairs[i][2])
+	}
+	return
+}
+
 type BwrapInfo struct {
 	ChildPid int    `json:"child-pid"`
 	Raw      []byte `json:"-"`
@@ -421,7 +443,10 @@ type Bwrap struct {
 func StartBwrap(conf Config, flatpakMetadata FlatpakMetadata) (bwrap Bwrap) {
 	failed := true
 
-	bwrapArgs := append([]string{"--info-fd", "3", "--block-fd", "4"}, conf.BwrapArgs...)
+	bwrapArgs := conf.BwrapArgs
+	bwrapMounts := SortBindPaths(conf.BwrapMounts)
+	bwrapArgs = append([]string{"--info-fd", "3", "--block-fd", "4"}, bwrapArgs...)
+	bwrapArgs = append(bwrapArgs, bwrapMounts...)
 	if conf.UseFlatpakMetadata {
 		bwrapArgs = append(bwrapArgs, []string{"--ro-bind", flatpakMetadata.MetadataDirectory + "/info", "/.flatpak-info"}...)
 	}

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -2,7 +2,7 @@
 with lib;
 let
   # most of the things here should probably be incorporated into a module
-  
+
   # TODO: make a proper type for env vars or pathspecs
   coerceToEnv = val: let
     parsed = strings.match "^\\$([a-zA-Z0-9_]*)(/(.*))?$" val;
@@ -37,7 +37,7 @@ let
   bindDev = bind' "--dev-bind-try";
   setEnv = key: val: [ "--setenv" key val ];
   mountTmpfs = path: [ "--tmpfs" path ];
-  
+
   bindPaths = map bind config.bubblewrap.bind.rw;
   bindRoPaths = map bindRo config.bubblewrap.bind.ro;
   bindDevPaths = map bindDev config.bubblewrap.bind.dev;
@@ -49,7 +49,7 @@ let
   info = pkgs.closureInfo { inherit rootPaths; };
   launcher = pkgs.callPackage ../launcher {};
   dbusOutsidePath = concat (env "XDG_RUNTIME_DIR") (concat "/nixpak-bus-" instanceId);
-  
+
   pastaEnable = config.bubblewrap.network && config.pasta.enable;
 
   bwrapArgs = flatten [
@@ -57,7 +57,7 @@ let
     "--unshare-user-try"
     (optionals (!config.bubblewrap.shareIpc) "--unshare-ipc")
     "--unshare-pid"
-    "--unshare-net"      
+    "--unshare-net"
     "--unshare-uts"
     "--unshare-cgroup-try"
 
@@ -66,7 +66,7 @@ let
     (optionals (config.bubblewrap.clearEnv) "--clearenv")
     envVars
     tmpfs
-    
+
     (optionals (config.bubblewrap.network && !config.pasta.enable) "--share-net")
     (optionals config.bubblewrap.apivfs.dev ["--dev" "/dev"])
     (optionals config.bubblewrap.apivfs.proc ["--proc" "/proc"])
@@ -75,7 +75,7 @@ let
     (optionals config.bubblewrap.dieWithParent "--die-with-parent")
 
     bindDevPaths
-    
+
     (optionals config.dbus.enable [
       (bind [ dbusOutsidePath "$XDG_RUNTIME_DIR/nixpak-bus" ])
       "--setenv" "DBUS_SESSION_BUS_ADDRESS"
@@ -111,20 +111,31 @@ let
     inherit passthru;
     nativeBuildInputs = [ pkgs.makeWrapper ];
     meta = optionalAttrs (mainProgram != null) { inherit mainProgram; };
-  } (''
-    makeWrapper ${launcher}/bin/launcher $out${executablePath} \
-      ${concatStringsSep " " (flatten [
-        "--set BWRAP_EXE ${config.bubblewrap.package}/bin/bwrap"
-        "--set NIXPAK_APP_EXE ${app}${executablePath}"
-        "--set BUBBLEWRAP_ARGS ${bwrapArgsJson}"
-        "--set FLATPAK_METADATA_TEMPLATE ${config.flatpak.infoFile}"
-        (optionals config.dbus.enable "--set XDG_DBUS_PROXY_EXE ${dbusProxyWrapper}")
-        (optionals config.dbus.enable "--set XDG_DBUS_PROXY_ARGS ${dbusProxyArgsJson}")
-        (optionals pastaEnable "--set PASTA_EXE ${config.pasta.package}/bin/pasta")
-        (optionals pastaEnable "--set PASTA_ARGS ${pastaArgsJson}")
-        (optionals config.waylandProxy.enable "--set WAYLAND_PROXY_EXE ${config.waylandProxy.package}/bin/wayland-proxy-virtwl")
-        (optionals config.waylandProxy.enable "--set WAYLAND_PROXY_ARGS ${waylandProxyArgsJson}")
-      ])}
+  } (let
+    jsonData = {
+      app = {
+        exe = "${app}${executablePath}";
+      };
+      bwrap = {
+        exe = "${config.bubblewrap.package}/bin/bwrap";
+        args = bwrapArgsJson;
+      };
+      flatpak.metadata = config.flatpak.infoFile;
+      dbus = if (config.dbus.enable)
+        then { enable = true; exe = dbusProxyWrapper; args = dbusProxyArgsJson; }
+        else { enable = false; };
+      pasta = if (pastaEnable)
+        then { enable = true; exe = "${config.pasta.package}/bin/pasta"; args = pastaArgsJson; }
+        else { enable = false; };
+      wayland = if (config.waylandProxy.enable)
+        then { enable = true; exe = "${config.waylandProxy.package}/bin/wayland-proxy-virtwl"; args = waylandProxyArgsJson; }
+        else { enable = false; };
+    };
+  in ''
+    mkdir -p $(dirname $out${executablePath})
+    echo '#!${launcher}/bin/launcher' > $out${executablePath}
+    echo '${builtins.toJSON jsonData}' >> $out${executablePath}
+    chmod +x $out${executablePath}
   '');
 
   extraEntrypointScripts = genAttrs config.app.extraEntrypoints (entrypoint: mkWrapperScript {

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -61,11 +61,8 @@ let
     "--unshare-uts"
     "--unshare-cgroup-try"
 
-    bindPaths
-    bindRoPaths
     (optionals (config.bubblewrap.clearEnv) "--clearenv")
     envVars
-    tmpfs
 
     (optionals (config.bubblewrap.network && !config.pasta.enable) "--share-net")
     (optionals config.bubblewrap.apivfs.dev ["--dev" "/dev"])
@@ -81,17 +78,22 @@ let
       "--setenv" "DBUS_SESSION_BUS_ADDRESS"
       (concat "unix:path=" (coerceToEnv "$XDG_RUNTIME_DIR/nixpak-bus"))
     ])
-
+  ];
+  bwrapMounts = flatten [
+    tmpfs
+    bindPaths
+    bindRoPaths
     (optionals config.bubblewrap.bindEntireStore (bindRo "/nix/store"))
   ];
   dbusProxyArgs = [ (env "DBUS_SESSION_BUS_ADDRESS") dbusOutsidePath ] ++ config.dbus.args ++ [ "--filter" ];
 
-  originalBwrapArgs = pkgs.writeText "bwrap-args.json" (builtins.toJSON bwrapArgs);
-  bwrapArgsJson = if config.bubblewrap.bindEntireStore then originalBwrapArgs else pkgs.runCommand "bwrap-args.json" {
+  bwrapArgsJson = pkgs.writeText "bwrap-args.json" (builtins.toJSON bwrapArgs);
+  origBwrapMounts = pkgs.writeText "bwrap-mounts.json" (builtins.toJSON bwrapMounts);
+  bwrapMountsJson = if config.bubblewrap.bindEntireStore then origBwrapMounts else pkgs.runCommand "bwrap-mounts.json" {
     nativeBuildInputs = [ pkgs.jq ];
   } ''
     jq -nR '[inputs] | map("--ro-bind", ., .)' ${info}/store-paths > store-paths.json
-    jq -s '.[0] + .[1]' ${originalBwrapArgs} store-paths.json > $out
+    jq -s '.[0] + .[1]' ${origBwrapMounts} store-paths.json > $out
   '';
 
   dbusProxyArgsJson = pkgs.writeText "xdg-dbus-proxy-args.json" (builtins.toJSON dbusProxyArgs);
@@ -119,6 +121,7 @@ let
       bwrap = {
         exe = "${config.bubblewrap.package}/bin/bwrap";
         args = bwrapArgsJson;
+        mounts = bwrapMountsJson;
       };
       flatpak.metadata = config.flatpak.infoFile;
       dbus = if (config.dbus.enable)


### PR DESCRIPTION
Sorting the paths should allow read-write paths nested inside read-only paths. 

This allows config like this without getting "Read-only file system" error message:
```Nix
bind.ro = [
  (sloth.concat' sloth.homeDir "/dirname")
];
bind.rw = [
  (sloth.concat' sloth.homeDir "/dirname/path/to/other/dir")
];
```
This has to be done in the Go wrapper because of `sloth` we do not have the fullpath names inside the Nix config. Thus, sorting might not be so easy.