### PR TITLE
modules/gui/fonts: fix pathsToLink

### DIFF
--- a/modules/gui/fonts.nix
+++ b/modules/gui/fonts.nix
@@ -47,7 +47,7 @@ with lib;
         fontConfigFile
         pkgs.fontconfig.out
       ];
-      pathsToLink = "/etc/fonts";
+      pathsToLink = [ "/etc/fonts" ];
     };
   in mkIf cfg.enable {
     bubblewrap.extraStorePaths = [ fc ];


### PR DESCRIPTION
Fix: `pkgs.buildEnv error: Can't use string ("/etc/fonts") as an ARRAY ref while "strict refs" in use at /nix/store/smzh3zwg685bsjpz4mi772s55cx4ym3n-builder.pl line 18.`.