### PR TITLE
Add bubblewrap options for `--new-session` and `--die-with-parent`

### DIFF
--- a/modules/bubblewrap.nix
+++ b/modules/bubblewrap.nix
@@ -90,6 +90,12 @@ in {
       type = types.bool;
       default = false;
     };
+
+    dieWithParent = mkOption {
+      description = "Ensures child processes die when parent dies.";
+      type = types.bool;
+      default = false;
+    };
   };
 
   config = {

--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -72,6 +72,7 @@ let
     (optionals config.bubblewrap.apivfs.proc ["--proc" "/proc"])
 
     (optionals config.bubblewrap.newSession "--new-session")
+    (optionals config.bubblewrap.dieWithParent "--die-with-parent")
 
     bindDevPaths
     


### PR DESCRIPTION
Without `--new-session`, it is possible to escape bubblewrap's sandbox, see:
- https://github.com/containers/bubblewrap?tab=readme-ov-file#limitations
- https://github.com/containers/bubblewrap/issues/142

As for `--die-with-parent`, I think it can be useful to have when dealing with programs that really don't want to die.