### PR TITLE
pasta: support IPv6 in isolated mode

### DIFF
--- a/modules/pasta.nix
+++ b/modules/pasta.nix
@@ -36,7 +36,6 @@ with lib;
     # Disable services not needed due to --config-net
     "--no-dhcp"
     "--no-dhcpv6"
-    "--no-ndp"
     "--no-ra"
     # Mapping the gateway address to host also does not make sense in transparent mode, because this would prevent connections to the original gateway copied from host
     "--no-map-gw"


### PR DESCRIPTION
This is enough to make Hyprspace IPv6 addresses work, which is the main thing I'm interested in. Still need to test the general case.