### PR TITLE
Forbid substitutes for easily realised derivations

### DIFF
--- a/modules/launch.nix
+++ b/modules/launch.nix
@@ -87,7 +87,7 @@ let
   dbusProxyArgs = [ (env "DBUS_SESSION_BUS_ADDRESS") dbusOutsidePath ] ++ config.dbus.args ++ [ "--filter" ];
 
   originalBwrapArgs = pkgs.writeText "bwrap-args.json" (builtins.toJSON bwrapArgs);
-  bwrapArgsJson = if config.bubblewrap.bindEntireStore then originalBwrapArgs else pkgs.runCommand "bwrap-args.json" {
+  bwrapArgsJson = if config.bubblewrap.bindEntireStore then originalBwrapArgs else pkgs.runCommandLocal "bwrap-args.json" {
     nativeBuildInputs = [ pkgs.jq ];
   } ''
     jq -nR '[inputs] | map("--ro-bind", ., .)' ${info}/store-paths > store-paths.json
@@ -132,7 +132,7 @@ let
     executablePath = entrypoint;
   });
 
-  envOverrides = pkgs.runCommand "nixpak-overrides-${app.name}" {} (''
+  envOverrides = pkgs.runCommandLocal "nixpak-overrides-${app.name}" {} (''
     mkdir $out
     cd ${app}
     find . -type l | while read line; do


### PR DESCRIPTION
This change forbids substitutes for `bwrap-args.json` and `nixpak-overrides-`. These are unlikely to be cached, easily computed and do not require heavy dependencies. This should stop Nix from hitting cache.nixos.org for `bwrap-args.json` every time I change an option. I used `runCommandLocal` instead of `allowSubstitutes` because that results in smaller change and distributed builds are unlikely to be helpful for these computations either.