### PR TITLE
add gpu.bundlePackage to extraStorePaths when gpu.provider="bundle"

### DIFF
--- a/modules/gpu.nix
+++ b/modules/gpu.nix
@@ -45,6 +45,9 @@ in
       bind.ro = [
         [ "${config.gpu.bundlePackage}" "/run/opengl-driver" ]
       ];
+      extraStorePaths = [
+        config.gpu.bundlePackage
+      ];
     };
   }.${config.gpu.provider};
 }


### PR DESCRIPTION
**Problem**
I run `mpv` with `bindEntireStore = false; gpu = {enable = true; provider = "bundle"}` and get an error: `mpv: ../video/out/x11_common.c:679: vo_x11_init: Assertion '!vo->x11' failed.`

**Why**
Mesa has files pointing to paths in store, which are not in the package closure, so they don't get added to `/nix/store` in the sandbox.
```shell
$ cat /nix/store/inn3pgffv1qzwdcgaqcfvwkk3sspi9yk-mesa-26.1.5/share/vulkan/icd.d/radeon_icd.x86_64.json
{
    "ICD": {
        "api_version": "1.4.354",
        "library_arch": "64",
        "library_path": "/nix/store/inn3pgffv1qzwdcgaqcfvwkk3sspi9yk-mesa-26.1.5/lib/libvulkan_radeon.so"
    },
    "file_format_version": "1.0.1"
}
```


**Solution**
Add `bundlePackage` to `extraStorePaths` which will bring all files it depends on into the package closure.

As an aside, `gpu.provider="nixos"` also doesn't work because `/run/opengl-driver/lib` points to mesa in the store, which is not in the package closure. I had two solutions: either add `pkgs.mesa` or `builtins.storePath /run/opengl-driver` to `extraStorePaths`.  Both aren't good and will break with system updates. My current best idea on what to do is adding a recursive bind in launcher that will bind all symlinks in a directory which will also help with home-manager controlled configs. Better ideas are welcome.